### PR TITLE
fix uninitialized constant Tilt::HandlebarsTemplate::Pathname

### DIFF
--- a/lib/tilt/handlebars.rb
+++ b/lib/tilt/handlebars.rb
@@ -1,3 +1,4 @@
+require 'pathname'
 require 'tilt' unless defined? Tilt
 require 'handlebars'
 


### PR DESCRIPTION
using a partial that has not already been registered raising the "uninitialized constant Tilt::HandlebarsTemplate::Pathname" error.

``` ruby
require 'tilt/handlebars'
tmpl = Tilt.new 'hello.hbs'
puts tmpl.render name: 'railsconf'
```

templates:

**hello.hbs** template:

``` handlebars
{{> header}}

hello {{name}}!
```

**header.hbs** partial:

``` handlebars
<h1>HEADING</h1>
```
